### PR TITLE
Add "preconnect" resource hint

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -2,5 +2,7 @@
   type="text/x-handlebars"
   data-template-name="/connectors/above-site-header/fonts"
 >
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css?family={{theme-setting 'fonts'}}&display=swap" rel="stylesheet">
 </script>


### PR DESCRIPTION
A minor suggestion. This is also how Google Fonts offers the code snippet.

Resources:

* https://caniuse.com/link-rel-preconnect
* Google Fonts: https://fonts.google.com/share?selection.family=Inter:wght@400;700

![Screenshot 2023-01-20 at 4 24 46 PM](https://user-images.githubusercontent.com/291025/213829067-aedee100-d425-4f28-8ee4-9a9f0f02162c.png)
